### PR TITLE
Fixed the vpx_streamer typo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,7 +160,7 @@ add_library(${PROJECT_NAME}
 ## either from message generation or dynamic reconfigure
 # add_dependencies(vpx_image_transport ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 add_dependencies(${PROJECT_NAME} ${PROJECT_NAME}_gencfg ${PROJECT_NAME}_gencpp)
-add_dependencies(${PROJECT_NAME} webm-tools libyami vpx-streamer)
+add_dependencies(${PROJECT_NAME} webm-tools libyami vpx_streamer)
 
 ## Declare a C++ executable
 # add_executable(vpx_image_transport_node src/vpx_image_transport_node.cpp)
@@ -174,7 +174,7 @@ add_dependencies(${PROJECT_NAME} webm-tools libyami vpx-streamer)
 #   ${catkin_LIBRARIES}
 # )
 target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES}
-                                      ${vpx_streamer_LIBRARIES}
+                                      vpx_streamer
 )
 
 #############


### PR DESCRIPTION
To make the libvpx_image_transport.so successfuly links to
libvpx_streamer.so.